### PR TITLE
Allow developer environment detection for symfony custom environments

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -40,6 +40,10 @@ class Application
      * @var string
      */
     protected $applicationId;
+    
+    protected $developerEnvironments = array(
+        'dev',
+    );
 
     /**
      * @param ApplicationConfiguration $configuration
@@ -55,13 +59,29 @@ class Application
         $this->manifestLoader = $manifestLoader;
         $this->environment    = $environment;
     }
-
+    
+    /**
+     * @return array
+     */
+    public function getDeveloperEnvironments()
+    {
+        return $this->developerEnvironments;
+    }
+    
+    /**
+     * @param array $developerEnvironments
+     */
+    public function setDeveloperEnvironments(array $developerEnvironments = null)
+    {
+        $this->developerEnvironments = $developerEnvironments;
+    }
+    
     /**
      * @return bool
      */
     public function isDevelopment()
     {
-        return $this->environment == 'dev';
+        return in_array($this->environment, $this->developerEnvironments);
     }
 
     /**

--- a/src/Application.php
+++ b/src/Application.php
@@ -71,7 +71,7 @@ class Application
     /**
      * @param array $developerEnvironments
      */
-    public function setDeveloperEnvironments(array $developerEnvironments = null)
+    public function setDeveloperEnvironments(array $developerEnvironments)
     {
         $this->developerEnvironments = $developerEnvironments;
     }

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -183,10 +183,10 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
      */
     protected function createManifestLoaderMock()
     {
-        return $this->getMock(
-            'TQ\ExtJS\Application\Manifest\ManifestLoaderInterface',
-            array('loadManifest')
-        );
+        $mock = $this->getMockBuilder('TQ\ExtJS\Application\Manifest\ManifestLoaderInterface')
+            ->setMethods(array('loadManifest'))
+            ->getMock();
+        return $mock;
     }
 
     /**

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -35,6 +35,22 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($app->isDevelopment());
     }
+    
+    public function testCustomDevIsDevelopment()
+    {
+        $customDev = array('localhost', 'dev');
+        $app = $this->createDefaultApplication('localhost');
+        $app->setDeveloperEnvironments($customDev);
+        $this->assertTrue($app->isDevelopment());
+    }
+    
+    public function testProdWithCustomDevIsNotDevelopment()
+    {
+        $customDev = array('localhost', 'dev');
+        $app = $this->createDefaultApplication('prod');
+        $app->setDeveloperEnvironments($customDev);
+        $this->assertFalse($app->isDevelopment());
+    }
 
     public function testDevBasePath()
     {


### PR DESCRIPTION
the hard comparison for `$this->environment` against `"dev"` was causing issues when using custom environments (https://symfony.com/doc/current/configuration/environments.html). I've been kludging a fix by extending the `Application` class and overriding the `isDevelopment()` method. I figured that this might be more flexible for anyone else that is using this through symfony.